### PR TITLE
Disable default ncurses backend from cursive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ notify = "4.0"
 
 [dependencies.cursive]
 version = "0.15"
+default-features = false
 features = ["termion-backend"]
 
 [dependencies.chrono]


### PR DESCRIPTION
Cursive includes the ncurses backend by default, which requires building it and overall causes a bunch of unnecessary complications.