### PR TITLE
Allow to create habit with more than 1 word

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -104,7 +104,7 @@ fn call_on_app(s: &mut Cursive, input: &str) {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum Command {
     Add(String, Option<u32>, bool),
     MonthPrev,
@@ -219,24 +219,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_add_command_with_goal() {
-        let command: Vec<String> = "eat healthy 3"
-            .trim()
-            .split(' ')
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect();
+    fn parse_add_command() {
+        let result = Command::from_string("add eat 2");
 
-        let verb = "add".to_owned();
-        let auto = false;
-
-        let result = parse_add(verb, command, auto);
-
+        assert!(result.is_ok());
         match result.unwrap() {
-            Command::Add(name, goal, a) => {
-                assert_eq!(name, "eat healthy".to_owned());
-                assert_eq!(goal.unwrap(), 3);
-                assert_eq!(a, auto);
+            Command::Add(name, goal, auto) => {
+                assert_eq!(name, "eat");
+                assert_eq!(goal.unwrap(), 2);
+                assert_eq!(auto, false);
             }
             _ => panic!(),
         }
@@ -244,25 +235,138 @@ mod tests {
 
     #[test]
     fn parse_add_command_without_goal() {
-        let command: Vec<String> = "eat healthy"
-            .trim()
-            .split(' ')
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect();
+        let result = Command::from_string("add eat");
 
-        let verb = "add".to_owned();
-        let auto = false;
-
-        let result = parse_add(verb, command, auto);
-
+        assert!(result.is_ok());
         match result.unwrap() {
-            Command::Add(name, goal, a) => {
-                assert_eq!(name, "eat healthy".to_owned());
+            Command::Add(name, goal, auto) => {
+                assert_eq!(name, "eat");
                 assert!(goal.is_none());
-                assert_eq!(a, auto);
+                assert_eq!(auto, false);
             }
             _ => panic!(),
         }
+    }
+
+    // #[test]
+    fn parse_add_command_with_long_name() {
+        let result = Command::from_string("add \"eat healthy\" 5");
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Command::Add(name, goal, auto) => {
+                assert_eq!(name, "eat healthy");
+                assert_eq!(goal.unwrap(), 5);
+                assert_eq!(auto, false);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_add_auto_command() {
+        let result = Command::from_string("add-auto eat 2");
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Command::Add(name, goal, auto) => {
+                assert_eq!(name, "eat");
+                assert_eq!(goal.unwrap(), 2);
+                assert_eq!(auto, true);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_delete_command() {
+        let result = Command::from_string("delete eat");
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Command::Delete(name) => {
+                assert_eq!(name, "eat");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_track_up_command() {
+        let result = Command::from_string("track-up eat");
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Command::TrackUp(name) => {
+                assert_eq!(name, "eat");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_track_down_command() {
+        let result = Command::from_string("track-down eat");
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Command::TrackDown(name) => {
+                assert_eq!(name, "eat");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_help_command() {
+        let result = Command::from_string("help add");
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            Command::Help(name) => {
+                assert_eq!(name.unwrap(), "add");
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn parse_month_prev_command() {
+        let result = Command::from_string("mprev");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Command::MonthPrev);
+    }
+
+    #[test]
+    fn parse_month_next_command() {
+        let result = Command::from_string("mnext");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Command::MonthNext);
+    }
+
+    #[test]
+    fn parse_quit_command() {
+        let result = Command::from_string("q");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Command::Quit);
+    }
+
+    #[test]
+    fn parse_write_command() {
+        let result = Command::from_string("w");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Command::Write);
+    }
+
+    #[test]
+    fn parse_no_command() {
+        let result = Command::from_string("");
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Command::Blank);
     }
 }


### PR DESCRIPTION
I tried to create a habit with more than 1 word and an error was raised. I don't if this by design but if it's actually an error, I have created this PR to fix it. If it is by design, don't worry, I'll find another thing to develop and help `dijo` :).

The idea is that we concatenate all the `Strings` in the `Vec<String>` and check if the last one can be parsed as a `u32`. If this is the case, then it is the goal, if not, then is a `String` and is concatenate to the name. This allows to remove the `InvalidArg` error as it is not longer possible to put an invalid argument.

Regarding testing, I see that there are no tests and I don't know if there is any consensus about them. Anyway, I have added some as I feel more confortable developing but I can remove them.

I am very open to any suggestion, improvement or fix.