### PR TITLE
Adds "wq" command as a combination of "write" and "quit".

### DIFF
--- a/src/app/impl_self.rs
+++ b/src/app/impl_self.rs
@@ -249,10 +249,10 @@ impl App {
                                 "tdown" | "track-down" => "track-down <auto-habit-name>     (alias: tdown)",
                                 "q"     | "quit" => "quit dijo",
                                 "w"     | "write" => "write current state to disk   (alias: w)",
-                                "wq"    | "writeandquit" => "write current state to disk and quit dijo (alias: wq)",
                                 "h"|"?" | "help" => "help [<command>|commands|keys]     (aliases: h, ?)",
                                 "cmds"  | "commands" => "add, add-auto, delete, month-{prev,next}, track-{up,down}, help, quit",
                                 "keys" => "TODO", // TODO (view?)
+                                "wq" =>   "write current state to disk and quit dijo",
                                 _ => "unknown command or help topic.",
                             }
                         )
@@ -261,8 +261,7 @@ impl App {
                         self.message.set_message("help <command>|commands|keys")
                     }
                 }
-                Command::WriteAndQuit => self.save_state(),
-                Command::Quit | Command::Write => self.save_state(),
+                Command::Quit | Command::Write | Command::WriteAndQuit => self.save_state(),
                 Command::MonthNext => self.sift_forward(),
                 Command::MonthPrev => self.sift_backward(),
                 Command::Blank => {}

--- a/src/app/impl_self.rs
+++ b/src/app/impl_self.rs
@@ -249,6 +249,7 @@ impl App {
                                 "tdown" | "track-down" => "track-down <auto-habit-name>     (alias: tdown)",
                                 "q"     | "quit" => "quit dijo",
                                 "w"     | "write" => "write current state to disk   (alias: w)",
+                                "wq"    | "writeandquit" => "write current state to disk and quit dijo (alias: wq)",
                                 "h"|"?" | "help" => "help [<command>|commands|keys]     (aliases: h, ?)",
                                 "cmds"  | "commands" => "add, add-auto, delete, month-{prev,next}, track-{up,down}, help, quit",
                                 "keys" => "TODO", // TODO (view?)
@@ -260,6 +261,7 @@ impl App {
                         self.message.set_message("help <command>|commands|keys")
                     }
                 }
+                Command::WriteAndQuit => self.save_state(),
                 Command::Quit | Command::Write => self.save_state(),
                 Command::MonthNext => self.sift_forward(),
                 Command::MonthPrev => self.sift_backward(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,6 +20,7 @@ static COMMANDS: &'static [&'static str] = &[
     "quit",
     "write",
     "help",
+    "writeandquit",
 ];
 
 fn get_command_completion(prefix: &str) -> Option<String> {
@@ -98,8 +99,9 @@ fn call_on_app(s: &mut Cursive, input: &str) {
     // our main cursive object, has to be parsed again
     // here
     // TODO: fix this somehow
-    if let Ok(Command::Quit) = Command::from_string(input) {
-        s.quit();
+    match Command::from_string(input) {
+        Ok(Command::Quit) | Ok(Command::WriteAndQuit) => s.quit(),
+        _ => {}
     }
 }
 
@@ -115,6 +117,7 @@ pub enum Command {
     Write,
     Quit,
     Blank,
+    WriteAndQuit,
 }
 
 #[derive(Debug)]
@@ -196,6 +199,7 @@ impl Command {
             }
             "mprev" | "month-prev" => return Ok(Command::MonthPrev),
             "mnext" | "month-next" => return Ok(Command::MonthNext),
+            "wq" | "writeandquit" => return Ok(Command::WriteAndQuit),
             "q" | "quit" => return Ok(Command::Quit),
             "w" | "write" => return Ok(Command::Write),
             "" => return Ok(Command::Blank),


### PR DESCRIPTION
As a heavy Vim user I use this command **a lot** and since the release of Dijo the absence of it has bothered me (because muscle memory). 

I think the usual behavior of a Dijo user (or at least my own) is as follows:
- Complete the task you are tracking
- Open Dijo and mark the task as done
- Save your progress with _w_ or _write_ and press enter
- Quit with _q_ or _quit_ and press enter 

So it would be much nicer if we could just do _wq_ and enter.

This was a quick implementation so please let me know of any problems you may encounter.