### PR TITLE
Use an ordered map for serialization

### DIFF
--- a/src/habit/bit.rs
+++ b/src/habit/bit.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::default::Default;
 
 use chrono::NaiveDate;
@@ -37,7 +37,7 @@ impl From<bool> for CustomBool {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Bit {
     name: String,
-    stats: HashMap<NaiveDate, CustomBool>,
+    stats: BTreeMap<NaiveDate, CustomBool>,
     goal: CustomBool,
 
     #[serde(default = "default_auto")]
@@ -51,7 +51,7 @@ impl Bit {
     pub fn new(name: impl AsRef<str>, auto: bool) -> Self {
         return Bit {
             name: name.as_ref().to_owned(),
-            stats: HashMap::new(),
+            stats: BTreeMap::new(),
             goal: CustomBool(true),
             auto,
             inner_data: Default::default(),

--- a/src/habit/count.rs
+++ b/src/habit/count.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::default::Default;
 
 use chrono::NaiveDate;
@@ -12,7 +12,7 @@ use crate::habit::{InnerData, TrackEvent};
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Count {
     name: String,
-    stats: HashMap<NaiveDate, u32>,
+    stats: BTreeMap<NaiveDate, u32>,
     goal: u32,
 
     #[serde(default = "default_auto")]
@@ -26,7 +26,7 @@ impl Count {
     pub fn new(name: impl AsRef<str>, goal: u32, auto: bool) -> Self {
         return Count {
             name: name.as_ref().to_owned(),
-            stats: HashMap::new(),
+            stats: BTreeMap::new(),
             goal,
             auto,
             inner_data: Default::default(),

--- a/src/habit/float.rs
+++ b/src/habit/float.rs
@@ -1,5 +1,5 @@
 use std::cmp::{Eq, Ord, PartialEq};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::default::Default;
 use std::fmt;
 use std::ops::{Add, Sub};
@@ -80,7 +80,7 @@ impl Sub for FloatData {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Float {
     name: String,
-    stats: HashMap<NaiveDate, FloatData>,
+    stats: BTreeMap<NaiveDate, FloatData>,
     goal: FloatData,
     precision: u8,
     #[serde(default = "default_auto")]
@@ -94,7 +94,7 @@ impl Float {
     pub fn new(name: impl AsRef<str>, goal: u32, precision: u8, auto: bool) -> Self {
         return Float {
             name: name.as_ref().to_owned(),
-            stats: HashMap::new(),
+            stats: BTreeMap::new(),
             goal: FloatData {
                 value: goal,
                 precision,


### PR DESCRIPTION
This allows for a consistent serialization and can then be nicely versioned using git for example. I see no technical reason why a BTreeMap wouldn't work here.

This is for #156.