### PR TITLE
Past vs future day colors

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -25,6 +25,6 @@ pub fn theme_gen() -> Theme {
     return t;
 }
 
-pub fn cursor_bg() -> Color {
-    Light(cursive::theme::BaseColor::Black)
-}
+// pub fn cursor_bg() -> Color {
+//     Light(cursive::theme::BaseColor::Black)
+// }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,4 @@
-use cursive::theme::Color::{self, *};
+use cursive::theme::Color::*;
 use cursive::theme::PaletteColor::*;
 use cursive::theme::{BorderStyle, Palette, Theme};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,6 +44,8 @@ pub struct Colors {
     pub todo: String,
     #[serde(default = "light_black")]
     pub inactive: String,
+    #[serde(default = "magenta")]
+    pub future: String,
     #[serde(default = "dark_white")]
     pub cursor: String,
 }
@@ -117,6 +119,7 @@ impl Default for Colors {
             reached: cyan(),
             todo: magenta(),
             inactive: light_black(),
+            future: magenta(),
             cursor: light_black(),
         }
     }
@@ -150,6 +153,9 @@ impl AppConfig {
     }
     pub fn inactive_color(&self) -> Color {
         return Color::parse(&self.colors.inactive).unwrap_or(Color::Light(BaseColor::Black));
+    }
+    pub fn future_color(&self) -> Color {
+        return Color::parse(&self.colors.future).unwrap_or(Color::Dark(BaseColor::Magenta));
     }
     pub fn cursor_color(&self) -> Color {
         return Color::parse(&self.colors.cursor).unwrap_or(Color::Light(BaseColor::Black));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,68 +50,12 @@ pub struct Colors {
     pub cursor: String,
 }
 
-// Cyan and Magenta are dark by default
-fn cyan() -> String {
-    "cyan".into()
-}
-fn magenta() -> String {
-    "magenta".into()
-}
-fn light_black() -> String {
-    "light black".into()
-}
-#[allow(dead_code)]
-fn light_cyan() -> String {
-    "light cyan".into()
-}
-#[allow(dead_code)]
-fn light_magenta() -> String {
-    "light magenta".into()
-}
-#[allow(dead_code)]
-fn light_blue() -> String {
-    "light blue".into()
-}
-#[allow(dead_code)]
-fn light_green() -> String {
-    "light green".into()
-}
-#[allow(dead_code)]
-fn light_red() -> String {
-    "light red".into()
-}
-#[allow(dead_code)]
-fn light_white() -> String {
-    "light white".into()
-}
-#[allow(dead_code)]
-fn light_yellow() -> String {
-    "light yellow".into()
-}
-#[allow(dead_code)]
-fn dark_white() -> String {
-    "dark white".into()
-}
-#[allow(dead_code)]
-fn dark_black() -> String {
-    "dark black".into()
-}
-#[allow(dead_code)]
-fn dark_blue() -> String {
-    "dark blue".into()
-}
-#[allow(dead_code)]
-fn dark_green() -> String {
-    "dark green".into()
-}
-#[allow(dead_code)]
-fn dark_red() -> String {
-    "dark red".into()
-}
-#[allow(dead_code)]
-fn dark_yellow() -> String {
-    "dark yellow".into()
-}
+// NOTE: These function are only used as the default values for
+// the Colors struct above
+fn cyan()        -> String { "cyan".into()        }
+fn magenta()     -> String { "magenta".into()     }
+fn light_black() -> String { "light black".into() }
+fn dark_white()  -> String { "dark white".into()  }
 
 impl Default for Colors {
     fn default() -> Self {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,47 +58,58 @@ fn magenta() -> String {
 fn light_black() -> String {
     "light black".into()
 }
+#[allow(dead_code)]
 fn light_cyan() -> String {
     "light cyan".into()
 }
+#[allow(dead_code)]
 fn light_magenta() -> String {
     "light magenta".into()
 }
+#[allow(dead_code)]
 fn light_blue() -> String {
     "light blue".into()
 }
+#[allow(dead_code)]
 fn light_green() -> String {
     "light green".into()
 }
+#[allow(dead_code)]
 fn light_red() -> String {
     "light red".into()
 }
+#[allow(dead_code)]
 fn light_white() -> String {
     "light white".into()
 }
+#[allow(dead_code)]
 fn light_yellow() -> String {
     "light yellow".into()
 }
+#[allow(dead_code)]
 fn dark_white() -> String {
     "dark white".into()
 }
+#[allow(dead_code)]
 fn dark_black() -> String {
     "dark black".into()
 }
+#[allow(dead_code)]
 fn dark_blue() -> String {
     "dark blue".into()
 }
+#[allow(dead_code)]
 fn dark_green() -> String {
     "dark green".into()
 }
+#[allow(dead_code)]
 fn dark_red() -> String {
     "dark red".into()
 }
+#[allow(dead_code)]
 fn dark_yellow() -> String {
     "dark yellow".into()
 }
-
-
 
 impl Default for Colors {
     fn default() -> Self {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,8 +44,11 @@ pub struct Colors {
     pub todo: String,
     #[serde(default = "light_black")]
     pub inactive: String,
+    #[serde(default = "dark_white")]
+    pub cursor: String,
 }
 
+// Cyan and Magenta are dark by default
 fn cyan() -> String {
     "cyan".into()
 }
@@ -55,6 +58,47 @@ fn magenta() -> String {
 fn light_black() -> String {
     "light black".into()
 }
+fn light_cyan() -> String {
+    "light cyan".into()
+}
+fn light_magenta() -> String {
+    "light magenta".into()
+}
+fn light_blue() -> String {
+    "light blue".into()
+}
+fn light_green() -> String {
+    "light green".into()
+}
+fn light_red() -> String {
+    "light red".into()
+}
+fn light_white() -> String {
+    "light white".into()
+}
+fn light_yellow() -> String {
+    "light yellow".into()
+}
+fn dark_white() -> String {
+    "dark white".into()
+}
+fn dark_black() -> String {
+    "dark black".into()
+}
+fn dark_blue() -> String {
+    "dark blue".into()
+}
+fn dark_green() -> String {
+    "dark green".into()
+}
+fn dark_red() -> String {
+    "dark red".into()
+}
+fn dark_yellow() -> String {
+    "dark yellow".into()
+}
+
+
 
 impl Default for Colors {
     fn default() -> Self {
@@ -62,6 +106,7 @@ impl Default for Colors {
             reached: cyan(),
             todo: magenta(),
             inactive: light_black(),
+            cursor: light_black(),
         }
     }
 }
@@ -94,6 +139,9 @@ impl AppConfig {
     }
     pub fn inactive_color(&self) -> Color {
         return Color::parse(&self.colors.inactive).unwrap_or(Color::Light(BaseColor::Black));
+    }
+    pub fn cursor_color(&self) -> Color {
+        return Color::parse(&self.colors.cursor).unwrap_or(Color::Light(BaseColor::Black));
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -59,7 +59,8 @@ where
                     Style::none()
                 },
                 if !printer.focused {
-                    future_style
+                    // future_style
+                    past_style
                 } else {
                     Style::none()
                 },

--- a/src/views.rs
+++ b/src/views.rs
@@ -8,7 +8,7 @@ use chrono::prelude::*;
 use chrono::{Local, NaiveDate};
 
 use crate::habit::{Bit, Count, Float, Habit, TrackEvent, ViewMode};
-use crate::theme::cursor_bg;
+// use crate::theme::cursor_bg;
 use crate::utils::VIEW_WIDTH;
 
 use crate::CONFIGURATION;
@@ -115,7 +115,7 @@ where
                 let mut fs = future_style;
                 let grs = ColorStyle::front(CONFIGURATION.reached_color());
                 let ts = ColorStyle::front(CONFIGURATION.todo_color());
-                let cs = ColorStyle::back(cursor_bg());
+                let cs = ColorStyle::back(CONFIGURATION.cursor_color());
 
                 if self.reached_goal(d) {
                     day_style = day_style.combine(Style::from(grs));


### PR DESCRIPTION
Before every unmarked day was the same color. Now unmarked days before the current day are one color, while unmarked days after the current day are another.

See the last two days of this screenshot and compare it to the previous unmarked days.
To do this, set `future = "some color"` in the config file. (See left terminal)

![image](https://user-images.githubusercontent.com/73758476/204208887-e8453d5c-8db1-41c8-b437-adf2975f577e.png)
